### PR TITLE
🐛 Calendar events might be out-of-order when events are modified

### DIFF
--- a/duty_board/alchemy/api_queries.py
+++ b/duty_board/alchemy/api_queries.py
@@ -62,7 +62,7 @@ def get_calendars(session: SASession, all_encountered_person_uids: Set[int], tim
             last_update=format_datetime_for_timezone(single_calendar.last_update_utc, timezone),
             error_msg=single_calendar.error_msg or "",
             sync=single_calendar.sync,
-            events=events.get(single_calendar.uid) or [],
+            events=sorted((events.get(single_calendar.uid) or []), key=lambda event: event.start_event),
         )
         for single_calendar in result
     ]


### PR DESCRIPTION
When your OnCallEvents are already in the database, and the external calendar is modified, the modified OnCallEvents will be recreated. This causes the ordering of the events to change, which are then no longer ordered by start_date. The API then returns out-of-order calendars, which is also reflected in the front-end as we assume a sorted list in the API. 

This fix ensures that each calendar is locally sorted on start_event and thereby has an ordered result in the API.