### PR TITLE
Add duty team search

### DIFF
--- a/duty_board/www/js/App.tsx
+++ b/duty_board/www/js/App.tsx
@@ -17,6 +17,9 @@ import SingleCalendar from "./components/singleCalendar";
 import useErrorToast from "./utils/useErrorToast";
 
 const rootRoute = createRootRoute({
+  validateSearch: (search: Record<string, unknown>): { search?: string } => ({
+    search: typeof search.search === "string" ? search.search : undefined,
+  }),
   component: () => (
     <div>
       <div style={{minHeight: "100vh", display: "flex", flexDirection: "column"}}>

--- a/duty_board/www/js/components/expandedCalendarInfo.tsx
+++ b/duty_board/www/js/components/expandedCalendarInfo.tsx
@@ -3,13 +3,15 @@ import { Calendar, Events, Person } from "../api/api-generated-types";
 import ParsingError from "./parsingError";
 import ParsingWarning from "./parsingWarning";
 import PersonComponent from "./personComponent";
+import SearchHighlight from "./searchHighlight";
 
 interface Props {
   calendar: Calendar;
   persons: Map<string, Person>;
+  searchTerms?: string[];
 }
 
-const ExpandedCalendarInfo = ({ calendar, persons }: Props) => {
+const ExpandedCalendarInfo = ({ calendar, persons, searchTerms = [] }: Props) => {
   return (
     <Box bg="#f5f5f5">
       <Divider />
@@ -39,7 +41,7 @@ const ExpandedCalendarInfo = ({ calendar, persons }: Props) => {
       <Box p={10}>
         <Box>
           <Text as="b">Description</Text>
-          <Text>{calendar.description}</Text>
+          <Text><SearchHighlight searchTerms={searchTerms} text={calendar.description} /></Text>
         </Box>
         <Box mt={10}>
           <Text as="b">Schedule</Text>

--- a/duty_board/www/js/components/navbar.tsx
+++ b/duty_board/www/js/components/navbar.tsx
@@ -1,4 +1,3 @@
-import { ReactNode } from "react";
 import {
   Box,
   Flex,
@@ -19,9 +18,14 @@ import CompanyLogo from "./companyLogo";
 import { useGetSchedule } from "../api";
 import {Link, useMatch} from "@tanstack/react-router";
 import ExternalLink from "./externalLink";
+import SearchBox from "./searchBox";
 
-const NavLink = ({ children }: { children: ReactNode }) => (
-  <Link to="/$category" params={{ category: children }} activeProps={{ className: "font-bold" }}>
+const NavLink = ({ category }: { category: string }) => (
+  <Link to="/$category" params={{ category }} search={(previous) => {
+    const next = {...previous};
+    delete next.search;
+    return next;
+  }} activeProps={{ className: "font-bold" }}>
     <Box
       px={2}
       py={1}
@@ -31,7 +35,7 @@ const NavLink = ({ children }: { children: ReactNode }) => (
         bg: useColorModeValue("gray.200", "gray.700")
       }}
     >
-      {children}
+      {category}
     </Box>
   </Link>
 );
@@ -61,17 +65,11 @@ export default function Navbar() {
           />
           <HStack spacing={8} alignItems={"center"}>
             <CompanyLogo maxWidth={300} maxHeight={40} />
-            <HStack as={"nav"} spacing={4} display={{ base: "none", md: "flex" }}>
-              {config.categories.map((category: string) => (
-                category === enabledCategory ? (
-                  <Box textDecoration='underline'><NavLink key={"normal" + category}>{category}</NavLink></Box>
-                ) : (
-                  <Box><NavLink key={"normal" + category}>{category}</NavLink></Box>
-                )
-              ))}
-            </HStack>
           </HStack>
-          <Flex alignItems={"center"} mr={"20px"}>
+          <Flex alignItems={"center"} gap={4} ml={6} mr={"20px"}>
+            <Box display={{ base: "none", md: "block" }}>
+              <SearchBox />
+            </Box>
             {config.gitRepositoryUrl &&
               <Menu>
                 <ExternalLink href={config.gitRepositoryUrl} external={true}>
@@ -79,7 +77,6 @@ export default function Navbar() {
                       leftIcon={<AiFillGithub color={config.textColor} fontSize={"30px"}/>}
                       colorScheme='teal'
                       variant='outline'
-                      mr={"20px"}
                   >
                     <Text color={config.textColor}>Repo</Text>
                   </Button>
@@ -102,12 +99,33 @@ export default function Navbar() {
           </Flex>
         </Flex>
 
+        <Box
+          display={{ base: "none", md: "block" }}
+          overflowX="auto"
+          pb={3}
+          sx={{
+            "&::-webkit-scrollbar": {display: "none"},
+            scrollbarWidth: "none"
+          }}
+        >
+          <HStack as={"nav"} spacing={4} minW="max-content">
+            {config.categories.map((category: string) => (
+              category === enabledCategory ? (
+                <Box key={"normal" + category} textDecoration='underline'><NavLink category={category} /></Box>
+              ) : (
+                <Box key={"normal" + category}><NavLink category={category} /></Box>
+              )
+            ))}
+          </HStack>
+        </Box>
+
         {isOpen ? (
           <Box pb={4} display={{ md: "none" }}>
             <Stack as={"nav"} spacing={4}>
               {config.categories.map((category: string) => (
-                <NavLink key={"mobile" + category}>{category}</NavLink>
+                <NavLink category={category} key={"mobile" + category} />
               ))}
+              <SearchBox width="100%" />
             </Stack>
           </Box>
         ) : null}

--- a/duty_board/www/js/components/schedule.tsx
+++ b/duty_board/www/js/components/schedule.tsx
@@ -1,11 +1,84 @@
-import { Box, Divider, Stack } from "@chakra-ui/react";
-import { useMatch } from "@tanstack/react-router";
+import { Box, Divider, Stack, Text } from "@chakra-ui/react";
+import { useMatch, useSearch } from "@tanstack/react-router";
 import { useGetSchedule } from "../api";
-import { Calendar } from "../api/api-generated-types";
+import { Calendar, Person } from "../api/api-generated-types";
+import {calendarMatchesSearch, getSearchTerms} from "../utils/search";
+import SearchHighlight from "./searchHighlight";
 import SingleCalendar from "./singleCalendar";
+
+type CalendarRowProps = {
+  calendar: Calendar;
+  persons: Map<string, Person>;
+  searchTerms?: string[];
+};
+
+const CalendarRow = ({calendar, persons, searchTerms = []}: CalendarRowProps) => (
+  <Box key={calendar.uid}>
+    <Divider />
+    <SingleCalendar
+      category={calendar.category}
+      calendar={calendar}
+      persons={persons}
+      searchTerms={searchTerms}
+    />
+  </Box>
+);
+
+type CategoryScheduleProps = {
+  calendars: Calendar[];
+  category: string;
+  persons: Map<string, Person>;
+};
+
+const CategorySchedule = ({calendars, category, persons}: CategoryScheduleProps) => (
+  <>
+    {calendars
+      .filter((calendar) => calendar.category == category)
+      .map((calendar: Calendar) => (
+        <CalendarRow calendar={calendar} key={calendar.uid} persons={persons} />
+      ))}
+  </>
+);
+
+type SearchScheduleProps = {
+  calendars: Calendar[];
+  categories: string[];
+  persons: Map<string, Person>;
+  searchQuery: string;
+  searchTerms: string[];
+};
+
+const SearchSchedule = ({calendars, categories, persons, searchQuery, searchTerms}: SearchScheduleProps) => {
+  const shownCalendars = calendars.filter((calendar) => calendarMatchesSearch(calendar, searchTerms));
+  const groupedSearchResults = categories
+    .map((categoryName) => ({
+      calendars: shownCalendars.filter((calendar) => calendar.category === categoryName),
+      category: categoryName,
+    }))
+    .filter((group) => group.calendars.length > 0);
+
+  return (
+    <>
+      {shownCalendars.length === 0 ? (
+        <Text>No duty teams found for &quot;{searchQuery}&quot;.</Text>
+      ) : null}
+      {groupedSearchResults.map((group) => (
+        <Box key={group.category}>
+          <Text color="gray.600" fontSize="sm" fontWeight="semibold" mb={2} mt={2}>
+            <SearchHighlight searchTerms={searchTerms} text={group.category} />
+          </Text>
+          {group.calendars.map((calendar: Calendar) => (
+            <CalendarRow calendar={calendar} key={calendar.uid} persons={persons} searchTerms={searchTerms} />
+          ))}
+        </Box>
+      ))}
+    </>
+  );
+};
 
 const Schedule = () => {
   const data = useMatch("/$category", { strict: false });
+  const search = useSearch({strict: false}) as {search?: string};
   const {
     data: { config, calendars, persons }
   } = useGetSchedule();
@@ -14,24 +87,24 @@ const Schedule = () => {
     : config.categories[0];
 
   const personsMap = new Map(Object.entries(persons));
+  const searchQuery = (search.search ?? "").trim();
+  const searchTerms = getSearchTerms(search.search);
 
   // Design heavily influenced by https://chakra-templates.dev/page-sections/pricing
   return (
     <Box py={6} px={5} width={"100%"}>
       <Stack spacing={4} width={"100%"} direction={"column"}>
-        {calendars
-          .filter((calendar) => calendar.category == category)
-          .map((calendar: Calendar, index) => (
-            <Box key={index}>
-              <Divider />
-              <SingleCalendar
-                key={"singleCalendarNr" + index}
-                category={category}
-                calendar={calendar}
-                persons={personsMap}
-              />
-            </Box>
-          ))}
+        {searchQuery ? (
+          <SearchSchedule
+            calendars={calendars}
+            categories={config.categories}
+            persons={personsMap}
+            searchQuery={searchQuery}
+            searchTerms={searchTerms}
+          />
+        ) : (
+          <CategorySchedule calendars={calendars} category={category} persons={personsMap} />
+        )}
       </Stack>
     </Box>
   );

--- a/duty_board/www/js/components/searchBox.tsx
+++ b/duty_board/www/js/components/searchBox.tsx
@@ -1,0 +1,113 @@
+import {ChangeEvent, KeyboardEvent, useCallback, useEffect, useRef, useState} from "react";
+import {Input, InputGroup, InputGroupProps, InputLeftElement, InputRightElement, Text} from "@chakra-ui/react";
+import { FaSearch } from "@react-icons/all-files/fa/FaSearch";
+import {useNavigate, useSearch} from "@tanstack/react-router";
+
+type SearchBoxProps = {
+  width?: InputGroupProps["width"];
+};
+
+export default function SearchBox({width = "220px"}: SearchBoxProps) {
+  const navigate = useNavigate();
+  const search = useSearch({strict: false}) as {search?: string};
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [searchValue, setSearchValue] = useState(search.search ?? "");
+
+  const navigateWithSearch = useCallback((value: string) => {
+    void navigate({
+      replace: true,
+      search: (previous) => {
+        const next = {...previous};
+
+        if (value.trim()) {
+          return {...next, search: value};
+        }
+
+        delete next.search;
+        return next;
+      }
+    });
+  }, [navigate]);
+
+  useEffect(() => {
+    setSearchValue(search.search ?? "");
+  }, [search.search]);
+
+  useEffect(() => {
+    if (searchValue === (search.search ?? "")) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      navigateWithSearch(searchValue);
+    }, 500);
+
+    return () => window.clearTimeout(timeout);
+  }, [navigateWithSearch, search.search, searchValue]);
+
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const isTyping = target instanceof HTMLInputElement
+        || target instanceof HTMLTextAreaElement
+        || target?.isContentEditable;
+
+      if (event.key === "/" && !isTyping && !event.metaKey && !event.ctrlKey && !event.altKey) {
+        event.preventDefault();
+        inputRef.current?.focus();
+      }
+
+      if (event.key === "Escape" && !isTyping && search.search) {
+        setSearchValue("");
+        navigateWithSearch("");
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [navigateWithSearch, search.search]);
+
+  const onSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSearchValue(event.target.value);
+  };
+
+  const onSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Escape") {
+      return;
+    }
+
+    event.currentTarget.blur();
+    setSearchValue("");
+    navigateWithSearch("");
+  };
+
+  return (
+    <InputGroup width={width} size="sm">
+      <InputLeftElement color="gray.500" pointerEvents="none">
+        <FaSearch />
+      </InputLeftElement>
+      {!searchValue ? (
+        <InputRightElement alignItems="center" display="flex" pointerEvents="none">
+          <Text color="gray.500" fontSize="sm" lineHeight="1" transform="translateY(-1px)">/</Text>
+        </InputRightElement>
+      ) : null}
+      <Input
+        aria-label="Search"
+        bg="rgba(255, 255, 255, 0.8)"
+        border="none"
+        borderRadius="md"
+        color="gray.900"
+        onChange={onSearchChange}
+        onKeyDown={onSearchKeyDown}
+        placeholder="Search duty teams"
+        ref={inputRef}
+        value={searchValue}
+        _focusVisible={{
+          boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.7)"
+        }}
+        _placeholder={{color: "gray.500"}}
+      />
+    </InputGroup>
+  );
+}

--- a/duty_board/www/js/components/searchHighlight.tsx
+++ b/duty_board/www/js/components/searchHighlight.tsx
@@ -1,0 +1,23 @@
+import {Box} from "@chakra-ui/react";
+import {getHighlightParts} from "../utils/search";
+
+interface Props {
+  searchTerms?: string[];
+  text: string;
+}
+
+export default function SearchHighlight({searchTerms = [], text}: Props) {
+  const parts = getHighlightParts(text, searchTerms);
+
+  return (
+    <>
+      {parts.map((part, index) => (
+        part.highlighted ? (
+          <Box as="mark" bg="yellow.200" borderRadius="sm" color="inherit" key={index} px="1px">
+            {part.text}
+          </Box>
+        ) : part.text
+      ))}
+    </>
+  );
+}

--- a/duty_board/www/js/components/singleCalendar.tsx
+++ b/duty_board/www/js/components/singleCalendar.tsx
@@ -7,15 +7,17 @@ import { FaCalendarTimes } from "react-icons/fa";
 import PersonComponent from "./personComponent";
 import {useEffect, useState} from "react";
 import {Link, useMatch} from "@tanstack/react-router";
+import SearchHighlight from "./searchHighlight";
 
 interface Props {
   category: string;
   calendar: Calendar;
   persons: Map<string, Person>;
+  searchTerms?: string[];
 }
 
 // Huge credits to https://blog.logrocket.com/create-collapsible-react-components-react-collapsed/
-const SingleCalendar = ({ category, calendar, persons }: Props) => {
+const SingleCalendar = ({ category, calendar, persons, searchTerms = [] }: Props) => {
   const currentRoute = useMatch("/$category/$calendarId", { strict: false });
 
   const firstEvent = calendar.events.length > 0 ? calendar.events[0] : undefined;
@@ -52,7 +54,7 @@ const SingleCalendar = ({ category, calendar, persons }: Props) => {
         alignItems={{ md: "center" }}
       >
         <Box width={{base: "auto", md: "25%"}}>
-          <Heading size={"md"}>{calendar.name}</Heading>
+          <Heading size={"md"}><SearchHighlight searchTerms={searchTerms} text={calendar.name} /></Heading>
         </Box>
         <Box width={{base: "auto", md: "25%"}}>
           <List spacing={3} textAlign="start">
@@ -84,7 +86,7 @@ const SingleCalendar = ({ category, calendar, persons }: Props) => {
           <Stack>
             <div className="header">
               {isExpanded
-                  ? <Link to="/$category" params={{ category: category}}>
+                  ? <Link to="/$category" params={{ category: category}} search={(previous) => previous}>
                       <Button
                         size="md"
                         color={useColorModeValue(colorTextLight, colorTextDark)}
@@ -93,7 +95,7 @@ const SingleCalendar = ({ category, calendar, persons }: Props) => {
                         Close
                       </Button>
                     </Link>
-                  : <Link to="/$category/$calendarId" params={{ category: category, calendarId: calendar.uid }}>
+                  : <Link to="/$category/$calendarId" params={{ category: category, calendarId: calendar.uid }} search={(previous) => previous}>
                       <Button
                         size="md"
                         color={useColorModeValue(colorTextLight, colorTextDark)}
@@ -109,7 +111,7 @@ const SingleCalendar = ({ category, calendar, persons }: Props) => {
       </Stack>
       <div {...getCollapseProps()}>
         <div className="content">
-          <ExpandedCalendarInfo calendar={calendar} persons={persons} />
+          <ExpandedCalendarInfo calendar={calendar} persons={persons} searchTerms={searchTerms} />
         </div>
       </div>
     </>

--- a/duty_board/www/js/utils/search.ts
+++ b/duty_board/www/js/utils/search.ts
@@ -1,0 +1,43 @@
+import {Calendar} from "../api/api-generated-types";
+
+export interface HighlightPart {
+  highlighted: boolean;
+  text: string;
+}
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export const getSearchTerms = (query: string | undefined): string[] => (
+  (query ?? "")
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+);
+
+export const calendarMatchesSearch = (calendar: Calendar, searchTerms: string[]): boolean => {
+  if (searchTerms.length === 0) {
+    return true;
+  }
+
+  const searchableText = [calendar.name, calendar.description, calendar.category, calendar.uid]
+    .join(" ")
+    .toLowerCase();
+
+  return searchTerms.every((term) => searchableText.includes(term));
+};
+
+export const getHighlightParts = (text: string, searchTerms: string[] = []): HighlightPart[] => {
+  const terms = Array.from(new Set(searchTerms.filter(Boolean))).sort((a, b) => b.length - a.length);
+
+  if (terms.length === 0) {
+    return [{highlighted: false, text}];
+  }
+
+  const regex = new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "gi");
+
+  return text.split(regex).map((part) => ({
+    highlighted: terms.some((term) => term.toLowerCase() === part.toLowerCase()),
+    text: part,
+  }));
+};


### PR DESCRIPTION
Implemented global duty team search and improved navbar usability.

- Added frontend-based navbar search, no backend changes
- Added hotkeys: `/` focus shortcut and `Esc` to exit search
- Added multi-word matching across duty team name, description and category
- Grouped search results by category
- Highlighted search terms in the results
- Reworked navbar layout into two rows to reduce crowding

Default design (no search triggered):
<img width="1728" height="901" alt="Screenshot 2026-06-24 at 19 40 45" src="https://github.com/user-attachments/assets/0a7f561b-c3fc-4ce4-94a9-89bb7289d020" />

Search design:
<img width="1728" height="899" alt="Screenshot 2026-06-24 at 19 41 21" src="https://github.com/user-attachments/assets/1edb8ac0-12fa-47a4-8a8d-43a1d0a2b52c" />

